### PR TITLE
Implement termination checking in type system

### DIFF
--- a/Smythfile.lq
+++ b/Smythfile.lq
@@ -101,30 +101,42 @@ module SmythConfig contains
                                     (P::cons (Pair String String)
                                       (P::pair String String
                                         "test/typecheck/recursion_non_decreasing.lq"
-                                        "Recursion error: recur must use a structurally smaller argument")
+                                        "Recursion error: Parameter 'xs' passed unchanged to recur")
                                       (P::cons (Pair String String)
                                         (P::pair String String
-                                          "test/typecheck/vec_bad_motive.lq"
-                                          "Type mismatch")
+                                          "test/typecheck/recursion_in_compute.lq"
+                                          "Recursion error: recur is only allowed in value recursion")
                                         (P::cons (Pair String String)
                                           (P::pair String String
-                                            "test/typecheck/vec_bad_binder.lq"
-                                            "Type mismatch")
+                                            "test/typecheck/recursion_no_struct_param.lq"
+                                            "Recursion error: recur requires at least one data type parameter")
                                           (P::cons (Pair String String)
-                                        (P::pair String String
-                                          "test/typecheck/rewrite_non_equality.lq"
-                                          "Expected equality type")
-                                        (P::cons (Pair String String)
-                                          (P::pair String String
-                                            "test/typecheck/typeclass_no_instance.lq"
-                                            "No matching instance for Show")
-                                          (P::cons (Pair String String)
-                                          (P::pair String String
-                                            "test/errors/fuzzy_match_type.lq"
-                                              "Did you mean: Ar::add")
+                                            (P::pair String String
+                                              "test/typecheck/recursion_bare_recur.lq"
+                                              "Recursion error: recur must be applied")
                                             (P::cons (Pair String String)
                                               (P::pair String String
-                                                "test/errors/fuzzy_match_unqualified.lq"
-                                                "Did you mean: my-function?")
-                                              (P::nil (Pair String String)))))))))))))))))))))))))))
+                                                "test/typecheck/vec_bad_motive.lq"
+                                                "Type mismatch")
+                                              (P::cons (Pair String String)
+                                                (P::pair String String
+                                                  "test/typecheck/vec_bad_binder.lq"
+                                                  "Type mismatch")
+                                                (P::cons (Pair String String)
+                                                  (P::pair String String
+                                                    "test/typecheck/rewrite_non_equality.lq"
+                                                    "Expected equality type")
+                                                  (P::cons (Pair String String)
+                                                    (P::pair String String
+                                                      "test/typecheck/typeclass_no_instance.lq"
+                                                      "No matching instance for Show")
+                                                    (P::cons (Pair String String)
+                                                      (P::pair String String
+                                                        "test/errors/fuzzy_match_type.lq"
+                                                        "Did you mean: Ar::add")
+                                                      (P::cons (Pair String String)
+                                                        (P::pair String String
+                                                          "test/errors/fuzzy_match_unqualified.lq"
+                                                          "Did you mean: my-function?")
+                                                        (P::nil (Pair String String))))))))))))))))))))))))))))))))
 end

--- a/test/typecheck/recursion_bare_recur.lq
+++ b/test/typecheck/recursion_bare_recur.lq
@@ -1,0 +1,10 @@
+# Invalid recursion: recur must be applied, cannot be used bare
+
+import prelude as P
+
+module test::typecheck::recursion_bare_recur contains
+  define transparent bad-bare as
+    function xs (List Natural) returns (for-all ys as (List Natural) to Natural) value
+      recur
+    end
+end

--- a/test/typecheck/recursion_in_compute.lq
+++ b/test/typecheck/recursion_in_compute.lq
@@ -1,0 +1,13 @@
+# Invalid recursion: recur is only allowed in value recursion, not computations
+
+import prelude as P
+import io as IO
+
+module test::typecheck::recursion_in_compute contains
+  define transparent bad-compute as
+    function xs (List Natural) returns computation Unit compute
+      bind ignored from perform (IO::print "hello") then
+        return (recur xs)
+      end
+    end
+end

--- a/test/typecheck/recursion_no_struct_param.lq
+++ b/test/typecheck/recursion_no_struct_param.lq
@@ -1,0 +1,10 @@
+# Invalid recursion: recur requires at least one data type parameter
+
+import prelude as P
+
+module test::typecheck::recursion_no_struct_param contains
+  define transparent bad-no-struct as
+    function x Natural y Natural returns Natural value
+      recur (add-nat-prim x 1) y
+    end
+end

--- a/test/typecheck/recursion_valid.lq
+++ b/test/typecheck/recursion_valid.lq
@@ -1,0 +1,51 @@
+# Valid structural recursion - should type check successfully
+
+import prelude as P
+import arithmetic as Ar
+
+module test::typecheck::recursion_valid contains
+  # Simple structural recursion on a list
+  define transparent sum-list as
+    function xs (List Natural) returns Natural value
+      match xs of-type (List Natural) as ignored returns Natural
+        case List::empty as 0
+        case List::cons with h Natural t (List Natural) as
+          Ar::add h (recur t)
+      end
+    end
+
+  # Multiple parameters, structural decrease on one
+  define transparent length-with-acc as
+    function A Type0 xs (List A) acc Natural returns Natural value
+      match xs of-type (List A) as ignored returns Natural
+        case List::empty as acc
+        case List::cons with h A t (List A) as
+          recur A t (Ar::add acc 1)
+      end
+    end
+
+  # Nested pattern matching with structural recursion
+  define transparent last-or-default as
+    function A Type0 default A xs (List A) returns A value
+      match xs of-type (List A) as ignored returns A
+        case List::empty as default
+        case List::cons with h A t (List A) as
+          match t of-type (List A) as ignored returns A
+            case List::empty as h
+            case List::cons with h2 A t2 (List A) as recur A default t
+          end
+      end
+    end
+
+  # Let-bound structural subterm
+  define transparent map-with-let as
+    function A Type0 B Type0 f (for-all x as A to B) xs (List A) returns (List B) value
+      match xs of-type (List A) as ignored returns (List B)
+        case List::empty as P::nil B
+        case List::cons with h A t (List A) as
+          let value rest be recur A B f t in
+            P::cons B (f h) rest
+          end
+      end
+    end
+end


### PR DESCRIPTION
- Add detectDirectNonTermination to catch unchanged structural parameters
- Improve checkRecurCall error messages with detailed context
- Include allowed smaller values and parameter names in error output
- Add catMaybes helper for the new checking logic
- Add new test cases:
  - recursion_bare_recur.lq: test bare recur usage error
  - recursion_in_compute.lq: test recur in computation context
  - recursion_no_struct_param.lq: test recur without structural param
  - recursion_valid.lq: sanity check for valid structural recursion
- Update Smythfile.lq error-tests with new expected messages